### PR TITLE
Update Metrics to R8-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.mcstats.bukkit</groupId>
       <artifactId>metrics</artifactId>
-      <version>R7</version>
+      <version>R8-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Change to 1.9-Compatible Metrics Version

Fixes the following Issue: https://gist.github.com/willies952002/23eb1a2689b2d15bc943ac3265e1b51b
