### PR TITLE
Added 'Team' NBT tag for Mob entities

### DIFF
--- a/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/EntityNBT.java
+++ b/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/EntityNBT.java
@@ -100,6 +100,7 @@ public class EntityNBT extends EntityNBTBase {
 		cMob.add("NoAI", new BooleanVariable("NoAI"));
 		cMob.add("Persistent", new BooleanVariable("PersistenceRequired"));
 		cMob.add("LeftHanded", new BooleanVariable("LeftHanded"));
+		cMob.add("Team", new StringVariable("Team"));
 
 		NBTUnboundVariableContainer cBreed = new NBTUnboundVariableContainer("Breed", cMob);
 		cBreed.add("InLove", new IntegerVariable("InLove", 0));


### PR DESCRIPTION
Similar to adding 'Tags' - add the 'Team' NBT field to mobs so that they can be joined to a team using `/bos`