### PR TITLE
Fix bstats repo URL and enable github CI compile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,15 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-    - name: Run a one-line script
-      run: echo Hello, world!
-    - name: Run a multi-line script
-      run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </repository>
     <repository>
       <id>bstats-repo</id>
-      <url>https://repo.bstats.org/content/repositories/releases/</url>
+      <url>https://repo.codemc.org/repository/maven-public</url>
     </repository>
   </repositories>
 
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.bstats</groupId>
       <artifactId>bstats-bukkit</artifactId>
-      <version>1.2</version>
+      <version>1.5</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Looks like repo.bstats.org was retired, based on talk here: https://github.com/Bastian/bStats/issues/106

Updated the maven URL to point to the new repository mentioned in their getting started guide here: https://bstats.org/getting-started/include-metrics

Also updated the github workflow so it compiles the plugin. This also runs the couple of existing junit tests. Not exactly fancy CI, but better than nothing and should help you know whether pull requests will build or not.