### PR TITLE
Only deploy packages for pushes to master

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,6 +1,9 @@
 name: Java CI (Deploy)
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
It's possible to [push] to branches too! Probably don't want those built and deployed to your package repo (which I'm glad to see you set up - very cool)