### PR TITLE
1.15 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <inceptionYear>2013</inceptionYear>
 
   <properties>
-    <bukkit.version>1.14-R0.1-SNAPSHOT</bukkit.version>
+    <bukkit.version>1.15-R0.1-SNAPSHOT</bukkit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.timestamp>${maven.build.timestamp}</project.build.timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>

--- a/src/main/java/com/goncalomb/bukkit/mylib/reflect/NBTTypes.java
+++ b/src/main/java/com/goncalomb/bukkit/mylib/reflect/NBTTypes.java
@@ -31,7 +31,7 @@ final class NBTTypes {
 	private static HashMap<Class<?>, NBTTypes> _outerTypeMap = new HashMap<Class<?>, NBTTypes>();;
 
 	private Class<?> _class;
-	private Constructor<?> _contructor;
+	private Constructor<?> _constructor;
 	private Field _data;
 	private Class<?> _dataType;
 
@@ -83,12 +83,13 @@ final class NBTTypes {
 		_data = _class.getDeclaredField("data");
 		_data.setAccessible(true);
 		_dataType = _data.getType();
-		_contructor = _class.getConstructor(_dataType);
+		_constructor = _class.getDeclaredConstructor(_dataType);
+		_constructor.setAccessible(true);
 	}
 
 	// Wraps primitives and strings with Minecraft tags.
 	private Object wrap(Object innerObject) {
-		return BukkitReflect.newInstance(_contructor, innerObject);
+		return BukkitReflect.newInstance(_constructor, innerObject);
 	}
 
 	// Unwraps primitives and strings from Minecraft tags.

--- a/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/ItemNBT.java
+++ b/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/ItemNBT.java
@@ -11,8 +11,8 @@ import com.goncalomb.bukkit.nbteditor.nbt.variables.ColorVariable;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.IntegerVariable;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.MaterialListVariable;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.NBTUnboundVariableContainer;
+import com.goncalomb.bukkit.nbteditor.nbt.variables.RawJsonListVariable;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.RawJsonVariable;
-import com.goncalomb.bukkit.nbteditor.nbt.variables.StringListVariable;
 import com.goncalomb.bukkit.nbteditor.nbt.variables.StringVariable;
 
 public class ItemNBT extends BaseNBT {
@@ -22,7 +22,7 @@ public class ItemNBT extends BaseNBT {
 	static {
 		NBTUnboundVariableContainer cItem = new NBTUnboundVariableContainer("Item");
 		cItem.add("Name", new RawJsonVariable("display/Name"));
-		cItem.add("Lore", new StringListVariable("display/Lore"));
+		cItem.add("Lore", new RawJsonListVariable("display/Lore"));
 		cItem.add("Damage", new IntegerVariable("Damage"));
 		cItem.add("Unbreakable", new BooleanVariable("Unbreakable"));
 		cItem.add("CanDestroy", new MaterialListVariable("CanDestroy"));

--- a/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/variables/RawJsonListVariable.java
+++ b/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/variables/RawJsonListVariable.java
@@ -1,0 +1,32 @@
+package com.goncalomb.bukkit.nbteditor.nbt.variables;
+
+import org.bukkit.entity.Player;
+
+import com.goncalomb.bukkit.mylib.reflect.BukkitReflect;
+import com.goncalomb.bukkit.mylib.reflect.NBTTagList;
+
+public class RawJsonListVariable extends ListVariable {
+
+	public RawJsonListVariable(String key) {
+		super(key);
+	}
+
+	@Override
+	protected boolean addItem(NBTTagList list, String value, Player player) {
+		if (BukkitReflect.isValidRawJSON(value)) {
+			list.add(value);
+		} else {
+			if (player != null) {
+				player.sendMessage("§eInvalid raw JSON text, converting...");
+			}
+			list.add(BukkitReflect.textToRawJSON(value));
+		}
+		return true;
+	}
+
+	@Override
+	public String getFormat() {
+		return "List of raw JSON text (normal strings will be converted).";
+	}
+
+}


### PR DESCRIPTION
Surprisingly little changed in 1.15:

- They made the constructors private for the base NBT types for some ridiculous reason (handled here)
- Lore text is now JSON (handled here)
- They added Beehives, which are tile entities (not handled, not sure the right way to do this)

Seems to work on my 1.15 server. Can get books of souls and summon mobs, manipulate items, put items on mob in a spawner. Not an exhaustive test, but better than before. 