### PR TITLE
Fix NPE when saving villager offers on 1.15.2

### DIFF
--- a/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/variables/VillagerOffersVariable.java
+++ b/src/main/java/com/goncalomb/bukkit/nbteditor/nbt/variables/VillagerOffersVariable.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
 
 import com.goncalomb.bukkit.mylib.reflect.NBTTagCompound;
 import com.goncalomb.bukkit.mylib.reflect.NBTTagList;
@@ -39,7 +40,7 @@ public class VillagerOffersVariable extends NBTVariable implements SpecialVariab
 		NBTTagCompound getCompound() {
 			NBTTagCompound offer = new NBTTagCompound();
 			offer.setCompound("buy", NBTUtils.itemStackToNBTData(buyA));
-			if (buyB != null) {
+			if (buyB != null && !buyB.getType().equals(Material.AIR)) {
 				offer.setCompound("buyB", NBTUtils.itemStackToNBTData(buyB));
 			}
 			offer.setCompound("sell", NBTUtils.itemStackToNBTData(sell));


### PR DESCRIPTION
For some reason on 1.15.2 paper buyB is showing up as non-null AIR, which throws an NPE when attempting to get the item's handle for serialization. Likely there are other similar problems, but I haven't hit them yet. 